### PR TITLE
Allow story points with the suffix 'pt'

### DIFF
--- a/burndown.py
+++ b/burndown.py
@@ -13,7 +13,7 @@ COURSE_START = datetime(2021, 2, 3, tzinfo=TIMEZONE)
 COURSE_END = datetime(2021, 3, 21, tzinfo=TIMEZONE)
 
 # Something like (17), or (5.5) or (13P)
-STORY_PTS_PAREN_RE = re.compile(r"[\(\[](?P<pts>\d+(\.\d+)?)[Pp]?[\)\]]")
+STORY_PTS_PAREN_RE = re.compile(r"[\(\[](?P<pts>\d+(\.\d+)?)([Pp]t?)?[\)\]]")
 
 # Something like "weight: 0.5"
 STORY_PTS_INLINE_RE = re.compile(r"weight:\s+(?P<pts>\d+(\.\d+)?)\b")


### PR DESCRIPTION
We would like to use the suffix 'Pt' or 'pt' for our story points. This is also a requirement to use the browser extension [github-story-points](https://github.com/banyan/github-story-points).