### PR TITLE
Fix git fame arguments in script 'who-did-what.sh'

### DIFF
--- a/who-did-what.sh
+++ b/who-did-what.sh
@@ -1,10 +1,9 @@
 #!/bin/zsh
 
 
-TEAMS=()
-JUNK_FILES="*.ttf,*.bin,*.lock,*.json,*.save,*.jar,*.plist,*.xc*,*.properties,*.pbxproj"
-PERTINENT_FILES="*.gradle,*.kt,*.js,*.ex,*.exs,*.swift,*.py,*.sqlite,*.dart,*.bzl,*.ts,*.tsx,*.java"
-
+TEAMS=("vegify-1")
+JUNK_FILES="\.ttf$|\.bin$|\.lock$|\.json$|\.save$|\.jar$|\.plist$|\.xc$|\.properties$|\.pbxproj$"
+PERTINENT_FILES="\.gradle$|\.kt$|\.js$|\.ex$|\.exs$|\.swift$|\.py$|\.sqlite$|\.dart$|\.bzl$|\.ts$|\.tsx$|\.java$"
 
 rm -rf work
 mkdir work
@@ -16,13 +15,13 @@ do
     git clone --quiet "git@github.com:PSS-UU/${team}.git" $target_dir
     pushd $target_dir
     git fame \
-        --hide-progressbar \
-        --whitespace \
-        --by-type \
-        --format=csv \
-        --include=$PERTINENT_FILES
+        --silent-progress \
+        --ignore-whitespace \
+        --bytype \
+        --incl=$PERTINENT_FILES \
+        --excl=$JUNK_FILES \
+        --format=csv
     echo "=========="
     popd
 done
-
 

--- a/who-did-what.sh
+++ b/who-did-what.sh
@@ -3,7 +3,7 @@
 
 TEAMS=("vegify-1")
 JUNK_FILES="\.ttf$|\.bin$|\.lock$|\.json$|\.save$|\.jar$|\.plist$|\.xc$|\.properties$|\.pbxproj$"
-PERTINENT_FILES="\.gradle$|\.kt$|\.js$|\.ex$|\.exs$|\.swift$|\.py$|\.sqlite$|\.dart$|\.bzl$|\.ts$|\.tsx$|\.java$"
+PERTINENT_FILES="\.gradle$|\.kt$|\.kts$|\.js$|\.ex$|\.exs$|\.swift$|\.py$|\.pyo$|\.sqlite$|\.dart$|\.bzl$|\.ts$|\.tsx$|\.java$\.go$|\.rs$|\.php$|\.rb$"
 
 rm -rf work
 mkdir work

--- a/who-did-what.sh
+++ b/who-did-what.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
 
-TEAMS=("vegify-1")
+TEAMS=()
 JUNK_FILES="\.ttf$|\.bin$|\.lock$|\.json$|\.save$|\.jar$|\.plist$|\.xc$|\.properties$|\.pbxproj$"
 PERTINENT_FILES="\.gradle$|\.kt$|\.kts$|\.js$|\.ex$|\.exs$|\.swift$|\.py$|\.pyo$|\.sqlite$|\.dart$|\.bzl$|\.ts$|\.tsx$|\.java$\.go$|\.rs$|\.php$|\.rb$"
 


### PR DESCRIPTION
The arguments that are used in the script for `git fame` are not compatible anymore with the newest version of [git fame](https://github.com/casperdcl/git-fame).